### PR TITLE
Groq API call model modification

### DIFF
--- a/components/modules/malicious-url.tsx
+++ b/components/modules/malicious-url.tsx
@@ -131,7 +131,7 @@ export function MaliciousURL() {
           Authorization: `Bearer ${apiKey}`,
         },
         body: JSON.stringify({
-          model: "llama3-8b-8192",
+          model: "llama-3.3-70b-versatile",
           messages: [
             {
               role: "system",

--- a/components/modules/phishing-email.tsx
+++ b/components/modules/phishing-email.tsx
@@ -54,7 +54,7 @@ export function PhishingEmail() {
           "Authorization": `Bearer ${apiKey}`,
         },
         body: JSON.stringify({
-          model: "llama3-8b-8192",
+          model: "llama-3.3-70b-versatile",
           messages: [
             {
               role: "system",

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
I have modified the version of the model used in the API call to "llama-3.3-70b-versatile" from "llama3-8b-8192". Because "llama3-8b-8192" is deprecated.